### PR TITLE
96 Реализована проверка авторизации на бекэнде

### DIFF
--- a/packages/client/src/shared/config/routing/consts.ts
+++ b/packages/client/src/shared/config/routing/consts.ts
@@ -11,4 +11,4 @@ export const enum RoutePath {
   Error404 = '/404',
 }
 
-export const BASE_URL = 'https://ya-praktikum.tech/api/v2'
+export const BASE_URL = 'http://localhost:3001'

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -3,13 +3,122 @@ import dotenv from 'dotenv'
 dotenv.config()
 
 import express from 'express'
+import https from 'https'
 import { createClientAndConnect } from './db'
+import { authMiddleware } from './middleware/auth'
+import { createSession, Session } from './sessionStore'
 
 const app = express()
-app.use(cors())
+app.use(
+  cors({
+    origin: true,
+    credentials: true,
+  })
+)
+app.use(express.json())
+app.use(authMiddleware)
 const port = Number(process.env.SERVER_PORT) || 3001
 
 createClientAndConnect()
+
+const YA_SIGNIN_URL = 'https://ya-praktikum.tech/api/v2/auth/signin'
+
+const requestPractikumSignin = async (
+  login: string,
+  password: string
+): Promise<{ status: number; data: unknown; cookies: string[] }> => {
+  const payload = JSON.stringify({ login, password })
+  const url = new URL(YA_SIGNIN_URL)
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        method: 'POST',
+        hostname: url.hostname,
+        path: `${url.pathname}${url.search}`,
+        protocol: url.protocol,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      },
+      res => {
+        let rawBody = ''
+        res.on('data', chunk => {
+          rawBody += chunk
+        })
+
+        res.on('end', () => {
+          let data: unknown = rawBody
+          if (rawBody) {
+            try {
+              data = JSON.parse(rawBody)
+            } catch {
+              data = rawBody
+            }
+          }
+
+          const setCookie = res.headers['set-cookie']
+          const cookies = Array.isArray(setCookie)
+            ? setCookie
+            : setCookie
+            ? [setCookie]
+            : []
+
+          resolve({
+            status: res.statusCode || 500,
+            data,
+            cookies,
+          })
+        })
+      }
+    )
+
+    req.on('error', reject)
+    req.write(payload)
+    req.end()
+  })
+}
+
+app.post('/auth/signin', (req, res) => {
+  const { login, password } = req.body || {}
+
+  if (!login || !password) {
+    return res.status(400).json({ message: 'Login and password required' })
+  }
+
+  return requestPractikumSignin(login, password)
+    .then(({ status, data, cookies }) => {
+      if (status >= 400) {
+        return res.status(status).json(data)
+      }
+
+      const sid = createSession(login, cookies)
+
+      res.cookie('bff_sid', sid, {
+        httpOnly: true,
+        sameSite: 'lax',
+      })
+
+      return res.json({ ok: true })
+    })
+    .catch(() => res.status(502).json({ message: 'Signin failed' }))
+})
+
+app.get('/auth/user', (req, res) => {
+  const session = (req as typeof req & { session?: Session }).session
+  const login = session?.login || 'user'
+
+  return res.json({
+    id: 1,
+    first_name: login,
+    second_name: 'User',
+    avatar: '',
+    login,
+    email: `${login}@example.com`,
+    phone: '+10000000000',
+  })
+})
 
 app.get('/friends', (_, res) => {
   res.json([

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -93,9 +93,9 @@ app.post('/auth/signin', (req, res) => {
         return res.status(status).json(data)
       }
 
-      const sid = createSession(login, cookies)
+      const sessionId = createSession(login, cookies)
 
-      res.cookie('bff_sid', sid, {
+      res.cookie('bff_sid', sessionId, {
         httpOnly: true,
         sameSite: 'lax',
       })
@@ -107,7 +107,11 @@ app.post('/auth/signin', (req, res) => {
 
 app.get('/auth/user', (req, res) => {
   const session = (req as typeof req & { session?: Session }).session
-  const login = session?.login || 'user'
+  if (!session) {
+    return res.status(401).json({ message: 'Unauthorized' })
+  }
+
+  const { login } = session
 
   return res.json({
     id: 1,

--- a/packages/server/middleware/auth.ts
+++ b/packages/server/middleware/auth.ts
@@ -1,0 +1,49 @@
+import { NextFunction, Request, Response } from 'express'
+import { getSession } from '../sessionStore'
+
+const PUBLIC_PATHS = new Set(['/auth/signin'])
+
+const parseCookies = (cookieHeader?: string): Record<string, string> => {
+  if (!cookieHeader) {
+    return {}
+  }
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((acc, part) => {
+    const [rawKey, ...rest] = part.trim().split('=')
+    if (!rawKey) {
+      return acc
+    }
+
+    acc[rawKey] = decodeURIComponent(rest.join('='))
+    return acc
+  }, {})
+}
+
+export const authMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (req.method === 'OPTIONS') {
+    return next()
+  }
+
+  if (PUBLIC_PATHS.has(req.path)) {
+    return next()
+  }
+
+  const cookies = parseCookies(req.headers.cookie)
+  const sid = cookies.bff_sid
+
+  if (!sid) {
+    return res.status(401).json({ message: 'Unauthorized' })
+  }
+
+  const session = getSession(sid)
+  if (!session) {
+    return res.status(401).json({ message: 'Unauthorized' })
+  }
+
+  ;(req as Request & { session?: typeof session }).session = session
+  return next()
+}

--- a/packages/server/middleware/auth.ts
+++ b/packages/server/middleware/auth.ts
@@ -33,13 +33,13 @@ export const authMiddleware = (
   }
 
   const cookies = parseCookies(req.headers.cookie)
-  const sid = cookies.bff_sid
+  const sessionId = cookies.bff_sid
 
-  if (!sid) {
+  if (!sessionId) {
     return res.status(401).json({ message: 'Unauthorized' })
   }
 
-  const session = getSession(sid)
+  const session = getSession(sessionId)
   if (!session) {
     return res.status(401).json({ message: 'Unauthorized' })
   }

--- a/packages/server/sessionStore.ts
+++ b/packages/server/sessionStore.ts
@@ -1,0 +1,28 @@
+import crypto from 'crypto'
+
+export type Session = {
+  login: string
+  praktikumCookies: string[]
+  createdAt: number
+}
+
+const sessions = new Map<string, Session>()
+
+const generateSessionId = (): string => crypto.randomBytes(32).toString('hex')
+
+export const createSession = (
+  login: string,
+  praktikumCookies: string[]
+): string => {
+  const sid = generateSessionId()
+  sessions.set(sid, {
+    login,
+    praktikumCookies,
+    createdAt: Date.now(),
+  })
+  return sid
+}
+
+export const getSession = (sid: string): Session | null => {
+  return sessions.get(sid) || null
+}

--- a/packages/server/sessionStore.ts
+++ b/packages/server/sessionStore.ts
@@ -8,21 +8,24 @@ export type Session = {
 
 const sessions = new Map<string, Session>()
 
-const generateSessionId = (): string => crypto.randomBytes(32).toString('hex')
+const SESSION_ID_BYTES = 32
+
+const generateSessionId = (): string =>
+  crypto.randomBytes(SESSION_ID_BYTES).toString('hex')
 
 export const createSession = (
   login: string,
   praktikumCookies: string[]
 ): string => {
-  const sid = generateSessionId()
-  sessions.set(sid, {
+  const sessionId = generateSessionId()
+  sessions.set(sessionId, {
     login,
     praktikumCookies,
     createdAt: Date.now(),
   })
-  return sid
+  return sessionId
 }
 
-export const getSession = (sid: string): Session | null => {
-  return sessions.get(sid) || null
+export const getSession = (sessionId: string): Session | null => {
+  return sessions.get(sessionId) || null
 }


### PR DESCRIPTION
### Какую задачу решаем
#96 

- Добавил middleware, который проверяет наличие bff_sid в cookie и валидирует сессию в in‑memory хранилище. Без валидной сессии сервер возвращает 401.
- Добавил POST /auth/signin, который проксирует логин на https://ya-praktikum.tech/api/v2/auth/signin, сохраняет полученные cookies в сессию и выставляет нашу httpOnly cookie bff_sid.

### Скриншоты/видяшка (если есть)

### TBD (если есть)